### PR TITLE
fix for when developer copies the access token including bearer

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -344,7 +344,9 @@ module GoCardless
     end
 
     def merchant_id
+      puts @access_token.inspect
       raise ClientError, 'Access token missing' unless @access_token
+      raise ClientError, 'Access token does contain manage_merchant:' if @access_token.token.include? 'bearer'
       scope = @access_token.params['scope'].split
       perm = scope.select {|p| p.start_with?('manage_merchant:') }.first
       perm.split(':')[1]

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -384,5 +384,12 @@ describe GoCardless::Client do
         @client.send(:merchant_id)
       end.to raise_exception GoCardless::ClientError
     end
+    
+    it "fails if the access token does not contains bearer" do
+      lambda do
+        @client.access_token = 'bearer TOKEN'
+        @client.send(:merchant_id)
+      end.should raise_exception GoCardless::ClientError
+    end
   end
 end


### PR DESCRIPTION
... you get a sane error not a split exception
