### PR TITLE
Removing resource_uri from confirm_resource

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -218,7 +218,7 @@ module GoCardless
       params = Utils.symbolize_keys(Hash[params])
       # Only pull out the relevant parameters, other won't be included in the
       # signature so will cause false negatives
-      keys = [:resource_id, :resource_type, :resource_uri, :state, :signature]
+      keys = [:resource_id, :resource_type, :state, :signature]
       params = Hash[params.select { |k,v| keys.include? k }]
       (keys - [:state]).each do |key|
         raise ArgumentError, "Parameters missing #{key}" if !params.key?(key)

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -227,12 +227,11 @@ describe GoCardless::Client do
     before :each do
       @params = {
         :resource_id   => '1',
-        :resource_uri  => 'a',
         :resource_type => 'subscription',
       }
     end
 
-    [:resource_id, :resource_uri, :resource_type].each do |param|
+    [:resource_id, :resource_type].each do |param|
       it "fails when :#{param} is missing" do
         p = @params.tap { |d| d.delete(param) }
         expect { @client.confirm_resource p }.to raise_exception ArgumentError
@@ -241,7 +240,6 @@ describe GoCardless::Client do
 
     it "does not fail when keys are strings in a HashWithIndiferentAccess" do
       params = {'resource_id' => 1,
-                'resource_uri' => 'a',
                 'resource_type' => 'subscription',
                 'signature' => 'foo'}
       params_indifferent_access = HashWithIndifferentAccess.new(params)


### PR DESCRIPTION
Spotted that the resource_uri param seems to be redundant in confirm_resource.
Either that or it should be used to build the request uri?
Developer documentation may need updating too...
