### PR TITLE
Add cancel! method to GoCardless::PreAuthorization 

### DIFF
--- a/lib/gocardless/pre_authorization.rb
+++ b/lib/gocardless/pre_authorization.rb
@@ -25,6 +25,12 @@ module GoCardless
     def create_bill(attrs)
       Bill.new_with_client(client, attrs.merge(:source => self)).save
     end
+
+    def cancel!
+      path = self.class.endpoint.gsub(':id', id.to_s) + '/cancel'
+      client.api_put(path)
+    end
+
   end
 end
 

--- a/spec/pre_authorization_spec.rb
+++ b/spec/pre_authorization_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe GoCardless::PreAuthorization do
+  before :each do
+    @app_id = 'abc'
+    @app_secret = 'xyz'
+    GoCardless.account_details = {:app_id => @app_id, :app_secret => @app_secret,
+                                  :token  => 'xxx manage_merchant:1'}
+    @client = GoCardless.client
+  end
+
+  it "should be cancellable" do
+    s = GoCardless::PreAuthorization.new_with_client(@client, :id => '009988')
+    @client.expects(:api_put).with('/pre_authorizations/009988/cancel')
+    s.cancel!
+  end
+
+end


### PR DESCRIPTION
Hi. I've added a method to cancel a pre_authorization, so now the gem should work as described in documentation. 

``` ruby
pre_auth = GoCardless::PreAuthorization.find("0540QD22SKND")
pre-auth.cancel!
```
