### PR TITLE
Remove explicit rubygems requires

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'multi_json'
 require 'oauth2'
 require 'openssl'

--- a/lib/gocardless/errors.rb
+++ b/lib/gocardless/errors.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'multi_json'
 
 module GoCardless


### PR DESCRIPTION
It's an anti-pattern that's actively discouraged:

http://chneukirchen.github.com/rps/
http://tomayko.com/writings/require-rubygems-antipattern
http://yehudakatz.com/2009/07/24/rubygems-good-practice/
http://stackoverflow.com/a/3307759
