### PR TITLE
Environment variables for client app_id and app_secret

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -30,8 +30,8 @@ module GoCardless
 
     def initialize(args = {})
       Utils.symbolize_keys! args
-      @app_id = args[:app_id]
-      @app_secret = args[:app_secret]
+      @app_id = args.fetch(:app_id) { ENV['GOCARDLESS_APP_ID'] }
+      @app_secret = args.fetch(:app_secret) { ENV['GOCARDLESS_APP_SECRET'] }
       raise ClientError.new("You must provide an app_id") unless @app_id
       raise ClientError.new("You must provide an app_secret") unless @app_secret
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -37,6 +37,13 @@ describe GoCardless::Client do
       end.should raise_exception(GoCardless::ClientError)
     end
 
+    it "does not raise an error if the credentials are provided as environment variables" do
+      ENV.expects(:[]).with('GOCARDLESS_APP_ID').returns(@app_id)
+      ENV.expects(:[]).with('GOCARDLESS_APP_SECRET').returns(@app_secret)
+
+      GoCardless::Client.new
+    end
+
     it "sets a merchant id if it's given" do
       client = GoCardless::Client.new({
         :app_id      => @app_id,


### PR DESCRIPTION
So best practice for storing credentials for external services within an app is to use environment variables, as described nicely here: http://www.12factor.net/config

Using this technique to store GoCardless credentials is currently very verbose. This change adds support for defaulting to environment variables if app_id and app_secret options were not specified explicitly.

Before:

``` ruby
GoCardless::Client.new(app_id: ENV['GOCARDLESS_APP_ID'], app_secret: ENV['GOCARDLESS_APP_SECRET'])
```

After:

``` ruby
GoCardless::Client.new
```

Alternative naming could be GOCARDLESS_CLIENT_ID and GOCARDLESS_CLIENT_SECRET, not sure what your preferences are on that.

Cheers,
Tim
