### PR TITLE
Use date_accessor to define next_interval_start methods

### DIFF
--- a/lib/gocardless/pre_authorization.rb
+++ b/lib/gocardless/pre_authorization.rb
@@ -11,11 +11,11 @@ module GoCardless
                   :description,
                   :plan_id,
                   :status,
-                  :remaining_amount,
-                  :next_interval_start
+                  :remaining_amount
 
     reference_accessor :merchant_id, :user_id
-    date_accessor :expires_at, :created_at
+
+    date_accessor :expires_at, :created_at, :next_interval_start
 
     # Create a new bill under this pre-authorization. Similar to
     # {Client#create_bill}, but only requires the amount to be specified.

--- a/lib/gocardless/subscription.rb
+++ b/lib/gocardless/subscription.rb
@@ -13,12 +13,11 @@ module GoCardless
                    :status,
                    :setup_fee,
                    :trial_length,
-                   :trial_unit,
-                   :next_interval_start
+                   :trial_unit
 
     reference_accessor :merchant_id, :user_id
 
-    date_accessor :start_at, :expires_at, :created_at
+    date_accessor :start_at, :expires_at, :created_at, :next_interval_start
 
 
     def cancel!


### PR DESCRIPTION
The next_interval_start methods on subscription and pre-auth classes are currently defined using attr_accessor instead of date_accessor.

Values can potentially be null/nil, but date_accessor appears to handle that already (it will only parse strings to DateTime.parse).

Cheers,
Tim
