### PR TITLE
Remove display_name attribute from User class

### DIFF
--- a/lib/gocardless/user.rb
+++ b/lib/gocardless/user.rb
@@ -2,7 +2,7 @@ module GoCardless
   class User < Resource
     self.endpoint = '/users/:id'
 
-    attr_accessor :name, :first_name, :last_name, :email, :display_name
+    attr_accessor :name, :first_name, :last_name, :email
     date_accessor :created_at
   end
 end


### PR DESCRIPTION
Can't see this attribute in the documentation or in responses, presumably you used to have it and removed it?
