### PR TITLE
fixes documentation for Client#create_bill

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -170,7 +170,8 @@ module GoCardless
     # Create a new bill under a given pre-authorization
     # @see PreAuthorization#create_bill
     #
-    # @param [Hash] attrs must include +:pre_authorization_id+ and +:amount+
+    # @param [Hash] attrs must include +:source_id+ (the id of the
+    # pre_authorization you want to bill from) and +:amount+
     # @return [Bill] the created bill object
     def create_bill(attrs)
       Bill.new_with_client(self, attrs).save


### PR DESCRIPTION
The documentation for the Client#create_bill method says you need to pass pre_authorization_id, it needs source_id instead.
