### PR TITLE
Make GoCardless fees and Partner Fees accessible.

### DIFF
--- a/lib/gocardless/bill.rb
+++ b/lib/gocardless/bill.rb
@@ -9,7 +9,9 @@ module GoCardless
                   :description,
                   :name,
                   :plan_id,
-                  :status
+                  :status,
+                  :gocardless_fees,
+                  :partner_fees
 
     # @attribute source_id
     # @return [String] the ID of the bill's source (eg subscription, pre_authorization)


### PR DESCRIPTION
I've added the fields for gocardless_fees and partner_fees to the library so they can be queried for each bill.
