### PR TITLE
Add check for nil params in webhook_valid?

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -261,7 +261,7 @@ module GoCardless
     # @param [Hash] params the contents of payload of the webhook
     # @return [Boolean] true when valid, false otherwise
     def webhook_valid?(params)
-      signature_valid?(params)
+      !params.nil? && signature_valid?(params)
     end
 
     # Set the base URL for this client instance. Overrides all other settings

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -458,6 +458,11 @@ describe GoCardless::Client do
   end
 
   describe "#webhook_valid?" do
+    it "returns false when params are nil" do
+      @client.webhook_valid?(nil).
+        should be_false
+    end
+
     it "returns false when the webhook signature is invalid" do
       @client.webhook_valid?({:some => 'stuff', :signature => 'invalid'}).
         should be_false


### PR DESCRIPTION
Hi, this helps preventing errors in case someone POST's to the callback url with no parameters.
