### PR TITLE
Add data for name attribute in attr_accessor

### DIFF
--- a/lib/gocardless/user.rb
+++ b/lib/gocardless/user.rb
@@ -6,7 +6,7 @@ module GoCardless
     date_accessor :created_at
 
     def name
-      "#{first_name} #{last_name}".rstrip
+      "#{first_name} #{last_name}".strip
     end
   end
 end

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -1,10 +1,33 @@
 require 'spec_helper'
 
 describe GoCardless::User do
-  let(:user) { GoCardless::User.new(:id => 123, :first_name => "first", :last_name => "last") }
+  let(:user) { GoCardless::User.new(:id => 123, :first_name => first, :last_name => last) }
 
   describe "#name" do
     subject { user.name }
-    it { should == "first last" }
+
+    context "with first and last name" do
+      let(:first) { "First" }
+      let(:last) { "Last" }
+      it { should == "First Last" }
+    end
+
+    context "with first name only" do
+      let(:first) { "First" }
+      let(:last) { nil }
+      it { should == "First" }
+    end
+
+    context "with last name only" do
+      let(:first) { nil }
+      let(:last) { "Last" }
+      it { should == "Last" }
+    end
+
+    context "with no first or last name" do
+      let(:first) { nil }
+      let(:last) { nil }
+      it { should == "" }
+    end
   end
 end


### PR DESCRIPTION
Currently `name` is an accessible attribute on user, but always returns `nil`.

This constructs a name from `first_name` and `last_name`.
