### PR TITLE
Add rake development dependency

### DIFF
--- a/gocardless.gemspec
+++ b/gocardless.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'mocha', '~> 0.9.12'
   gem.add_development_dependency 'yard', '~> 0.7.3'
   gem.add_development_dependency 'activesupport', '~> 3.1'
+  gem.add_development_dependency 'rake', '~> 10.0'
 
   gem.authors = ['Harry Marr', 'Tom Blomfield']
   gem.description = %q{A Ruby wrapper for the GoCardless API}


### PR DESCRIPTION
Running `bundle exec rake spec` fails with Gem::LoadError ("rake is not part of the bundle. Add it to Gemfile").
