### PR TITLE
Adds can_be_retried attribute with question mark accessor

### DIFF
--- a/lib/gocardless/bill.rb
+++ b/lib/gocardless/bill.rb
@@ -11,7 +11,8 @@ module GoCardless
                   :plan_id,
                   :status,
                   :gocardless_fees,
-                  :partner_fees
+                  :partner_fees,
+                  :can_be_retried
 
     # @attribute source_id
     # @return [String] the ID of the bill's source (eg subscription, pre_authorization)
@@ -50,6 +51,10 @@ module GoCardless
         }
       })
       self
+    end
+
+    def can_be_retried?
+      can_be_retried
     end
 
     def pending?

--- a/spec/bill_spec.rb
+++ b/spec/bill_spec.rb
@@ -81,4 +81,16 @@ describe GoCardless::Bill do
       GoCardless::Bill.new.refunded?.should be_false
     end
   end
+
+  describe "can be retried query method" do
+    it "returns true when the can_be_refunded attribute is true" do
+      GoCardless::Bill.new(:can_be_retried => true).can_be_retried?.
+        should be_true
+    end
+
+    it "returns false otherwise" do
+      GoCardless::Bill.new.can_be_retried?.should be_false
+    end
+  end
+
 end


### PR DESCRIPTION
This adds support for the new `can_be_retried` attribute in the GoCardless API. It also includes a `can_be_retried?` method to match up with Ruby idioms.
