### PR TITLE
Use double in place of mock or stub

### DIFF
--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -101,7 +101,7 @@ describe GoCardless::Client do
     describe "with valid params" do
       let(:oauth_client) { @client.instance_variable_get(:@oauth_client) }
       let(:fake_token) do
-        stub(:params => {'scope' => 'manage_merchant:x'}, :token  => 'abc')
+        double(:params => {'scope' => 'manage_merchant:x'}, :token  => 'abc')
       end
 
       before { oauth_client.auth_code.stub(:get_token).and_return(fake_token) }
@@ -182,7 +182,7 @@ describe GoCardless::Client do
     it "uses the correct path prefix" do
       @client.access_token = 'TOKEN123'
       token = @client.instance_variable_get(:@access_token)
-      r = mock
+      r = double
       r.stub(:parsed)
       token.should_receive(:get).with { |p,o| p =~ %r|/api/v1/test| }.and_return(r)
       @client.api_get('/test')
@@ -197,7 +197,7 @@ describe GoCardless::Client do
     it "encodes data to json" do
       @client.access_token = 'TOKEN123'
       token = @client.instance_variable_get(:@access_token)
-      r = mock
+      r = double
       r.stub(:parsed)
       token.should_receive(:post).with { |p,opts| opts[:body] == '{"a":1}' }.and_return(r)
       @client.api_post('/test', {:a => 1})
@@ -212,7 +212,7 @@ describe GoCardless::Client do
     it "encodes data to json" do
       @client.access_token = 'TOKEN123'
       token = @client.instance_variable_get(:@access_token)
-      r = mock
+      r = double
       r.stub(:parsed)
       token.should_receive(:delete).with { |p,opts| opts[:body] == '{"a":1}' }.and_return(r)
       @client.api_delete('/test', {:a => 1})
@@ -227,7 +227,7 @@ describe GoCardless::Client do
     it "looks up the correct merchant" do
       @client.access_token = 'TOKEN'
       @client.merchant_id = '123'
-      response = mock
+      response = double
       response.should_receive(:parsed)
 
       token = @client.instance_variable_get(:@access_token)
@@ -242,7 +242,7 @@ describe GoCardless::Client do
     it "creates a Merchant object" do
       @client.access_token = 'TOKEN'
       @client.merchant_id = '123'
-      response = mock
+      response = double
       response.should_receive(:parsed).and_return({:name => 'test', :id => 123})
 
       token = @client.instance_variable_get(:@access_token)
@@ -311,12 +311,12 @@ describe GoCardless::Client do
 
     it "confirms the resource when the signature is valid" do
       # Once for confirm, once to fetch result
-      @client.should_receive(:request).twice.and_return(stub(:parsed => {}))
+      @client.should_receive(:request).twice.and_return(double(:parsed => {}))
       @client.confirm_resource(@client.send(:sign_params, @params))
     end
 
     it "and_return the correct object when the signature is valid" do
-      @client.stub(:request).and_return(stub(:parsed => {}))
+      @client.stub(:request).and_return(double(:parsed => {}))
       subscription = GoCardless::Subscription.new_with_client @client
       GoCardless::Subscription.should_receive(:find_with_client).and_return subscription
 
@@ -373,7 +373,7 @@ describe GoCardless::Client do
       params_indifferent_access = HashWithIndifferentAccess.new(params)
       expect do
         @client.response_params_valid? params_indifferent_access
-      end.to_not raise_exception ArgumentError
+      end.to_not raise_exception
     end
 
     it "rejects other params not required for the signature" do

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -63,7 +63,7 @@ describe GoCardless::Resource do
       test_resource = Class.new(GoCardless::Resource) do
         self.endpoint = '/test/:id'
       end
-      mock_client = mock
+      mock_client = double
       mock_client.should_receive(:api_get).and_return({:id => 123})
       resource = test_resource.find_with_client(mock_client, 123)
       resource.should be_a test_resource
@@ -76,7 +76,7 @@ describe GoCardless::Resource do
       test_resource = Class.new(GoCardless::Resource) do
         self.endpoint = '/test/:id'
       end
-      GoCardless.stub(:client => mock)
+      GoCardless.stub(:client => double)
       test_resource.should_receive(:find_with_client).with(GoCardless.client, 1)
       test_resource.find(1)
       unset_ivar GoCardless, :client
@@ -211,7 +211,7 @@ describe GoCardless::Resource do
       end
 
       it "sends the correct data parameters" do
-        client = mock
+        client = double
         data = {:x => 1, :y => 2}
         resource = @test_resource.new_with_client(client, data)
         client.should_receive(:api_post).with(anything, data)
@@ -219,21 +219,21 @@ describe GoCardless::Resource do
       end
 
       it "sends the correct path" do
-        client = mock
+        client = double
         resource = @test_resource.new_with_client(client)
         client.should_receive(:api_post).with('/test', anything)
         resource.save
       end
 
       it "POSTs when not persisted" do
-        client = mock
+        client = double
         resource = @test_resource.new_with_client(client)
         client.should_receive(:api_post)
         resource.save
       end
 
       it "PUTs when already persisted" do
-        client = mock
+        client = double
         resource = @test_resource.new_with_client(client, :id => 1)
         client.should_receive(:api_put)
         resource.save
@@ -283,7 +283,7 @@ describe GoCardless::Resource do
     end
 
     attrs = {:id => 1, :uri => 'http:', :x => 'y'}
-    resource = test_resource.new_with_client(mock, attrs)
+    resource = test_resource.new_with_client(double, attrs)
     resource.to_hash.should == attrs
   end
 
@@ -356,14 +356,14 @@ describe GoCardless::Resource do
     end
 
     it "use the correct uri path" do
-      client = mock()
+      client = double()
       client.should_receive(:api_get).with('/api/bills/', anything).and_return([])
       r = @test_resource.new_with_client(client, @attrs)
       r.bills
     end
 
     it "strips the api prefix from the path" do
-      client = mock()
+      client = double()
       client.should_receive(:api_get).with('/bills/', anything).and_return([])
       uris = {'bills' => 'https://test.com/api/v123/bills/'}
       r = @test_resource.new_with_client(client, 'sub_resource_uris' => uris)
@@ -371,14 +371,14 @@ describe GoCardless::Resource do
     end
 
     it "use the correct query string params" do
-      client = mock()
+      client = double()
       client.should_receive(:api_get).with(anything, 'merchant_id' => '1').and_return([])
       r = @test_resource.new_with_client(client, @attrs)
       r.bills
     end
 
     it "adds provided params to existing query string params" do
-      client = mock()
+      client = double()
       params = { 'merchant_id' => '1', :amount => '10.00' }
       client.should_receive(:api_get).with(anything, params).and_return([])
       r = @test_resource.new_with_client(client, @attrs)
@@ -386,7 +386,7 @@ describe GoCardless::Resource do
     end
 
     it "adds provided params when there are no existing query string params" do
-      client = mock()
+      client = double()
       params = { :source_id => 'xxx' }
       client.should_receive(:api_get).with(anything, params).and_return([])
       r = @test_resource.new_with_client(client, {
@@ -398,7 +398,7 @@ describe GoCardless::Resource do
     end
 
     it "return instances of the correct resource class" do
-      client = stub(:api_get => [{:id => 1}])
+      client = double(:api_get => [{:id => 1}])
       r = @test_resource.new_with_client(client, @attrs)
       ret = r.bills
       ret.should be_a Array

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'active_support/hash_with_indifferent_access'
 require 'gocardless'
 
 def stub_get(client, data)
-  response = mock
+  response = double
   response.stub(:parsed).and_return(data)
 
   token = client.instance_variable_get(:@access_token)


### PR DESCRIPTION
That. Removes deprecation warnings from our specs.
