### PR TITLE
Fix for all resources called on merchant

### DIFF
--- a/lib/gocardless/resource.rb
+++ b/lib/gocardless/resource.rb
@@ -185,7 +185,7 @@ module GoCardless
         # sub_resource_uri, with the query params provided by the user
         query = default_query.merge(args.first || {})
 
-        Paginator.new(client, self, path, query)
+        Paginator.new(client, klass, path, query)
       end
     end
   end


### PR DESCRIPTION
`GoCardless.client.merchant.(preauthorizations|users|payouts).to_a` works after this change, the `each` method was throwing an exception (it was trying to use GoCardless::Merchant as the resource type for all resources)
