### PR TITLE
Uses a constant time string comparison to avoid timing attacks.

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -418,7 +418,7 @@ module GoCardless
     def signature_valid?(params)
       params = params.clone
       signature = params.delete(:signature)
-      sign_params(params)[:signature] == signature
+      Utils.secure_compare(sign_params(params)[:signature], signature)
     end
 
     # Generate a random base64-encoded string

--- a/lib/gocardless/utils.rb
+++ b/lib/gocardless/utils.rb
@@ -94,6 +94,25 @@ module GoCardless
       OpenSSL::HMAC.hexdigest(digest, key, msg)
     end
 
+    # Given two strings, compare them in constant time (for the length of the
+    # string). This can avoid timing attacks when used to compare signed
+    # parameters.
+    # Borrowed from ActiveSupport::MessageVerifier.
+    # https://github.com/rails/rails/blob/master/activesupport/lib/active_support/message_verifier.rb
+    #
+    # @param [String] the first string to compare
+    # @param [String] this second string to compare
+    # @return [Boolean] the result of the comparison
+    def secure_compare(a, b)
+      return false unless a.bytesize == b.bytesize
+
+      l = a.unpack("C#{a.bytesize}")
+
+      res = 0
+      b.each_byte { |byte| res |= byte ^ l.shift }
+      res == 0
+    end
+
     # Format a Time object according to ISO 8601, and convert to UTC.
     #
     # @param [Time] time the time object to format

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -26,6 +26,16 @@ describe GoCardless::Utils do
         GoCardless::Utils.singularize("cacti").should == "cactus"
       end
     end
+
+    describe '.secure_compare' do
+      it 'is true for the same strings' do
+        GoCardless::Utils.secure_compare('hello', 'hello').should be_truthy
+      end
+
+      it 'is false for different strings' do
+        GoCardless::Utils.secure_compare('hello', 'banjo').should be_falsey
+      end
+    end
   end
 
   describe "hash helpers" do


### PR DESCRIPTION
Ruby's == string comparison will short circuit once it knows the string is not the same. This could allow a potential attacker to figure out the app secret with a timing attack against the user's webhook endpoint. This uses ActiveSupport's secure compare function to avoid that.

I've made this PR against the fix-spec-deprecations branch as I branched off there since the tests were broken for me on master.
