### PR TITLE
Handle nil values in secure_compare util

### DIFF
--- a/lib/gocardless/client.rb
+++ b/lib/gocardless/client.rb
@@ -418,6 +418,7 @@ module GoCardless
     def signature_valid?(params)
       params = params.clone
       signature = params.delete(:signature)
+      return false unless signature
       Utils.secure_compare(sign_params(params)[:signature], signature)
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -346,6 +346,11 @@ describe GoCardless::Client do
       params = {:signature => 'invalid'}.merge(@params)
       @client.send(:signature_valid?, params).should be_falsey
     end
+
+    it "fails with a nil signature" do
+      params = {:signature => nil}.merge(@params)
+      @client.send(:signature_valid?, params).should be_falsey
+    end
   end
 
   describe "#confirm_resource" do


### PR DESCRIPTION
It's possible to have a nil value for the signature when checking a webhook is valid (although obviously not if its GoCardless that sent the webhook). We should handle these in the `secure_compare` method.
