### PR TITLE
Upgrade RSpec & Convert specs to RSpec 3.1.7 syntax with Transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 group :development do
   gem "guard", "~> 0.8.8"
+  gem "rspec", "~> 3.1"
   if RUBY_PLATFORM.downcase.include?("darwin")
     gem "guard-rspec", "~> 0.5.4"
     gem "rb-fsevent", "~> 0.9"

--- a/spec/bill_spec.rb
+++ b/spec/bill_spec.rb
@@ -13,28 +13,28 @@ describe GoCardless::Bill do
     bill.source_type = :subscription
     stub_get(client, :id => 123)
     source = bill.source
-    source.should be_a GoCardless::Subscription
-    source.id.should == 123
+    expect(source).to be_a GoCardless::Subscription
+    expect(source.id).to eq(123)
   end
 
   it "source setter works" do
     bill.source = GoCardless::Subscription.new(:id => 123)
-    bill.source_id.should == 123
-    bill.source_type.should.to_s == 'subscription'
+    expect(bill.source_id).to eq(123)
+    expect(bill.source_type.to_s).to eq('subscription')
   end
 
   it "should be able to be retried" do
-    client.should_receive(:api_post).with('/bills/123/retry')
+    expect(client).to receive(:api_post).with('/bills/123/retry')
     bill.retry!
   end
 
   it "should be able to be cancelled" do
-    client.should_receive(:api_put).with('/bills/123/cancel')
+    expect(client).to receive(:api_put).with('/bills/123/cancel')
     bill.cancel!
   end
 
   it "should be able to be refunded" do
-    client.should_receive(:api_post).with('/bills/123/refund')
+    expect(client).to receive(:api_post).with('/bills/123/refund')
     bill.refund!
   end
 

--- a/spec/gocardless_spec.rb
+++ b/spec/gocardless_spec.rb
@@ -10,7 +10,7 @@ describe GoCardless do
 
   describe ".account_details=" do
     it "creates a Client instance" do
-      GoCardless::Client.should_receive :new
+      expect(GoCardless::Client).to receive :new
       subject.account_details = @details
     end
 
@@ -26,7 +26,7 @@ describe GoCardless do
     %w(new_subscription_url new_pre_authorization_url new_bill_url confirm_resource webhook_valid?).each do |name|
       it "#{name} delegates to @client" do
         subject.account_details = @details
-        subject.instance_variable_get(:@client).should_receive(name.to_sym)
+        expect(subject.instance_variable_get(:@client)).to receive(name.to_sym)
         subject.send(name)
       end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -14,12 +14,12 @@ describe GoCardless::Page do
 
     context "when there is next page available" do
       let(:links) {{ "next" => 2, "last" => 2 }}
-      it { should be_truthy }
+      it { is_expected.to be_truthy }
     end
 
     context "when there is no next page" do
       let(:links) {{ "previous" => 1, "first" => 1 }}
-      it { should be_falsey }
+      it { is_expected.to be_falsey }
     end
   end
 
@@ -28,12 +28,12 @@ describe GoCardless::Page do
 
     context "when there is next page available" do
       let(:links) {{ "next" => 2, "last" => 2 }}
-      it { should == 2 }
+      it { is_expected.to eq(2) }
     end
 
     context "when there is no next page" do
       let(:links) {{ "previous" => 1, "first" => 1 }}
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -42,12 +42,12 @@ describe GoCardless::Page do
 
     context "when there is previous page available" do
       let(:links) {{ "previous" => 1, "first" => 1 }}
-      it { should == 1 }
+      it { is_expected.to eq(1) }
     end
 
     context "when there is no previous page" do
       let(:links) {{ "next" => 2, "last" => 2 }}
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -56,12 +56,12 @@ describe GoCardless::Page do
 
     context "when there is first page available" do
       let(:links) {{ "first" => 1, "previous" => 1 }}
-      it { should == 1 }
+      it { is_expected.to eq(1) }
     end
 
     context "when there is no first page" do
       let(:links) {{ "next" => 2, "last" => 2 }}
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -70,12 +70,12 @@ describe GoCardless::Page do
 
     context "when there is last page available" do
       let(:links) {{ "next" => 2, "last" => 2 }}
-      it { should == 2 }
+      it { is_expected.to eq(2) }
     end
 
     context "when there is no last page" do
       let(:links) {{ "previous" => 1, "first" => 1 }}
-      it { should be_nil }
+      it { is_expected.to be_nil }
     end
   end
 
@@ -86,7 +86,7 @@ describe GoCardless::Page do
     end
 
     it "properly initialises the resources" do
-      page.map(&:id).should == ['a', 'b']
+      expect(page.map(&:id)).to eq(['a', 'b'])
     end
   end
 end

--- a/spec/paginator_spec.rb
+++ b/spec/paginator_spec.rb
@@ -19,7 +19,7 @@ describe GoCardless::Paginator do
   let(:response_p2) { double(:headers => headers_p2, :parsed => [{:id => 'b'}]) }
 
   let(:client) { double('client') }
-  before { client.stub(:api_request).and_return(response_p1, response_p2,
+  before { allow(client).to receive(:api_request).and_return(response_p1, response_p2,
                                                 response_p1, response_p2) }
 
   let(:paginator) { described_class.new(client, resource_class, path, query) }
@@ -28,17 +28,17 @@ describe GoCardless::Paginator do
   describe "#per_page" do
     context "given no arguments" do
       subject { paginator.per_page }
-      it { should == per_page }
+      it { is_expected.to eq(per_page) }
     end
 
     context "given an argument" do
       it "is chainable" do
-        paginator.per_page(60).should == paginator
+        expect(paginator.per_page(60)).to eq(paginator)
       end
     end
 
     it "resets pagination metadata" do
-      paginator.should_receive(:load_page).exactly(2).times
+      expect(paginator).to receive(:load_page).exactly(2).times
       paginator.count  # reset metadata, check that we have to reload it
       paginator.per_page(50)
       paginator.count
@@ -47,7 +47,7 @@ describe GoCardless::Paginator do
 
   describe "#load_page" do
     it "asks the client for the correct path" do
-      client.should_receive(:api_request).
+      expect(client).to receive(:api_request).
              with(:get, '/test', anything).
              and_return(response_p1)
       paginator.page(page_number)
@@ -55,9 +55,9 @@ describe GoCardless::Paginator do
 
     it "passes the correct pagination parameters through" do
       pagination_params = { :page => page_number, :per_page => per_page }
-      client.should_receive(:api_request) do |_, _, opts|
-        opts[:params].should include pagination_params
-      end.and_return(response_p1)
+      expect(client).to receive(:api_request) { |_, _, opts|
+        expect(opts[:params]).to include pagination_params
+      }.and_return(response_p1)
       paginator.page(page_number)
     end
   end
@@ -89,19 +89,19 @@ describe GoCardless::Paginator do
     context "when metadata is loaded" do
       before { paginator.page(1) }
 
-      it { should == 15 }
+      it { is_expected.to eq(15) }
 
       it "doesn't reload metadata" do
-        paginator.should_not_receive(:load_page)
+        expect(paginator).not_to receive(:load_page)
         paginator.count
       end
     end
 
     context "when metadata is not loaded" do
-      it { should == 15 }
+      it { is_expected.to eq(15) }
 
       it "loads metadata" do
-        paginator.should_receive(:load_page)
+        expect(paginator).to receive(:load_page)
         paginator.count
       end
     end
@@ -113,19 +113,19 @@ describe GoCardless::Paginator do
     context "when metadata is loaded" do
       before { paginator.page(1) }
 
-      it { should == 2 }
+      it { is_expected.to eq(2) }
 
       it "doesn't reload metadata" do
-        paginator.should_not_receive(:load_page)
+        expect(paginator).not_to receive(:load_page)
         paginator.page_count
       end
     end
 
     context "when metadata is not loaded" do
-      it { should == 2 }
+      it { is_expected.to eq(2) }
 
       it "loads metadata" do
-        paginator.should_receive(:load_page)
+        expect(paginator).to receive(:load_page)
         paginator.page_count
       end
     end

--- a/spec/pre_authorization_spec.rb
+++ b/spec/pre_authorization_spec.rb
@@ -9,7 +9,7 @@ describe GoCardless::PreAuthorization do
   let(:preauth) { GoCardless::PreAuthorization.new(:id => '009988') }
 
   it "should be cancellable" do
-    client.should_receive(:api_put).with('/pre_authorizations/009988/cancel')
+    expect(client).to receive(:api_put).with('/pre_authorizations/009988/cancel')
     preauth.cancel!
   end
 

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -7,7 +7,7 @@ describe GoCardless::Resource do
     end
     props = {:id => 1, :name => 'test', :uri => 'http://test'}
     resource = test_resource.new(props)
-    props.each { |k,v| resource.send(k).should == v }
+    props.each { |k,v| expect(resource.send(k)).to eq(v) }
   end
 
   describe "#date_writer" do
@@ -16,16 +16,16 @@ describe GoCardless::Resource do
     end
 
     describe "creates date writers" do
-      specify { test_resource.instance_methods.map(&:to_sym).should include :created_at= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :modified_at= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :created_at= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :modified_at= }
     end
 
     it "date writers work properly" do
       time = '2011-12-12T12:00:00Z'
       resource = test_resource.new(:created_at => time)
       date_time = resource.instance_variable_get(:@created_at)
-      date_time.should be_instance_of DateTime
-      date_time.strftime('%Y-%m-%dT%H:%M:%SZ').should == time
+      expect(date_time).to be_instance_of DateTime
+      expect(date_time.strftime('%Y-%m-%dT%H:%M:%SZ')).to eq(time)
     end
   end
 
@@ -35,17 +35,17 @@ describe GoCardless::Resource do
     end
 
     describe "creates date readers and writers" do
-      specify { test_resource.instance_methods.map(&:to_sym).should include :created_at= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :created_at }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :modified_at= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :modified_at }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :created_at= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :created_at }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :modified_at= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :modified_at }
     end
 
     it "date readers work properly" do
       resource = test_resource.new
       date = DateTime.now
       resource.instance_variable_set(:@created_at, date)
-      resource.created_at.should == date
+      expect(resource.created_at).to eq(date)
     end
   end
 
@@ -56,10 +56,10 @@ describe GoCardless::Resource do
 
     it "instantiates the correct object" do
       mock_client = double
-      mock_client.should_receive(:api_get).and_return({:id => 123})
+      expect(mock_client).to receive(:api_get).and_return({:id => 123})
       resource = test_resource.find_with_client(mock_client, 123)
-      resource.should be_a test_resource
-      resource.id.should == 123
+      expect(resource).to be_a test_resource
+      expect(resource.id).to eq(123)
     end
   end
 
@@ -69,8 +69,8 @@ describe GoCardless::Resource do
     end
 
     it "calls find with the default client" do
-      GoCardless.stub(:client => double)
-      test_resource.should_receive(:find_with_client).with(GoCardless.client, 1)
+      allow(GoCardless).to receive_messages(:client => double)
+      expect(test_resource).to receive(:find_with_client).with(GoCardless.client, 1)
       test_resource.find(1)
       unset_ivar GoCardless, :client
     end
@@ -86,16 +86,16 @@ describe GoCardless::Resource do
     end
 
     describe "creates reference writers" do
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant_id= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user_id= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant_id= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user_id= }
     end
 
     it "direct assignment methods work properly" do
       resource = test_resource.new
       resource.user = GoCardless::User.new(:id => 123)
-      resource.instance_variable_get(:@user_id).should == 123
+      expect(resource.instance_variable_get(:@user_id)).to eq(123)
     end
 
     it "requires args to end with _id" do
@@ -124,10 +124,10 @@ describe GoCardless::Resource do
     end
 
     describe "creates reference readers" do
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant_id }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user_id }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant_id }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user_id }
     end
 
     it "lookup methods work properly" do
@@ -137,8 +137,8 @@ describe GoCardless::Resource do
       @client.merchant_id = '123'
       stub_get(@client, {:id => 123})
       user = resource.user
-      user.should be_a GoCardless::User
-      user.id.should == 123
+      expect(user).to be_a GoCardless::User
+      expect(user.id).to eq(123)
     end
 
     it "requires args to end with _id" do
@@ -158,20 +158,20 @@ describe GoCardless::Resource do
     end
 
     describe "creates reference readers and writers" do
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant_id }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user_id }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :merchant_id= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user= }
-      specify { test_resource.instance_methods.map(&:to_sym).should include :user_id= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant_id }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user_id }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :merchant_id= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user= }
+      specify { expect(test_resource.instance_methods.map(&:to_sym)).to include :user_id= }
     end
   end
 
   it "#persisted? works" do
-    GoCardless::Resource.new.persisted?.should be_falsey
-    GoCardless::Resource.new(:id => 1).persisted?.should be_truthy
+    expect(GoCardless::Resource.new.persisted?).to be_falsey
+    expect(GoCardless::Resource.new(:id => 1).persisted?).to be_truthy
   end
 
   describe "#save" do
@@ -193,28 +193,28 @@ describe GoCardless::Resource do
         client = double
         data = {:x => 1, :y => 2}
         resource = @test_resource.new_with_client(client, data)
-        client.should_receive(:api_post).with(anything, data)
+        expect(client).to receive(:api_post).with(anything, data)
         resource.save
       end
 
       it "sends the correct path" do
         client = double
         resource = @test_resource.new_with_client(client)
-        client.should_receive(:api_post).with('/test', anything)
+        expect(client).to receive(:api_post).with('/test', anything)
         resource.save
       end
 
       it "POSTs when not persisted" do
         client = double
         resource = @test_resource.new_with_client(client)
-        client.should_receive(:api_post)
+        expect(client).to receive(:api_post)
         resource.save
       end
 
       it "PUTs when already persisted" do
         client = double
         resource = @test_resource.new_with_client(client, :id => 1)
-        client.should_receive(:api_put)
+        expect(client).to receive(:api_put)
         resource.save
       end
     end
@@ -263,7 +263,7 @@ describe GoCardless::Resource do
 
     attrs = {:id => 1, :uri => 'http:', :x => 'y'}
     resource = test_resource.new_with_client(double, attrs)
-    resource.to_hash.should == attrs
+    expect(resource.to_hash).to eq(attrs)
   end
 
   it "#to_json converts to the correct JSON format" do
@@ -281,15 +281,15 @@ describe GoCardless::Resource do
     })
 
     result = MultiJson.decode(bill.to_json)
-    result['amount'].should == bill.amount
-    result['when'].should == time_str
-    result['person_id'].should == 15
+    expect(result['amount']).to eq(bill.amount)
+    expect(result['when']).to eq(time_str)
+    expect(result['person_id']).to eq(15)
   end
 
   describe "resource permissions" do
     it "are not given by default" do
-      GoCardless::Resource.creatable?.should be_falsey
-      GoCardless::Resource.updatable?.should be_falsey
+      expect(GoCardless::Resource.creatable?).to be_falsey
+      expect(GoCardless::Resource.updatable?).to be_falsey
     end
 
     it "are present when specified" do
@@ -301,14 +301,14 @@ describe GoCardless::Resource do
         updatable
       end
 
-      CreatableResource.creatable?.should be_truthy
-      CreatableResource.updatable?.should be_falsey
+      expect(CreatableResource.creatable?).to be_truthy
+      expect(CreatableResource.updatable?).to be_falsey
 
-      UpdatableResource.creatable?.should be_falsey
-      UpdatableResource.updatable?.should be_truthy
+      expect(UpdatableResource.creatable?).to be_falsey
+      expect(UpdatableResource.updatable?).to be_truthy
 
-      GoCardless::Resource.creatable?.should be_falsey
-      GoCardless::Resource.updatable?.should be_falsey
+      expect(GoCardless::Resource.creatable?).to be_falsey
+      expect(GoCardless::Resource.updatable?).to be_falsey
     end
   end
 
@@ -324,31 +324,31 @@ describe GoCardless::Resource do
 
     it "are defined on instances" do
       r = test_resource.new(@attrs)
-      r.should respond_to :bills
+      expect(r).to respond_to :bills
     end
 
     it "aren't defined for other instances of the class" do
       test_resource.new(@attrs)
       resource = test_resource.new
-      resource.should_not respond_to :bills
+      expect(resource).not_to respond_to :bills
     end
 
     it "use the correct resource" do
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, GoCardless::Bill, anything, anything)
       r = test_resource.new_with_client(double, @attrs)
       r.bills
     end
 
     it "use the correct uri path" do
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, anything, '/api/bills/', anything)
       r = test_resource.new_with_client(double, @attrs)
       r.bills
     end
 
     it "strips the api prefix from the path" do
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, anything, '/bills/', anything)
       uris = {'bills' => 'https://test.com/api/v123/bills/'}
       r = test_resource.new_with_client(double, 'sub_resource_uris' => uris)
@@ -357,7 +357,7 @@ describe GoCardless::Resource do
 
     it "use the correct query string params" do
       query = { 'merchant_id' => '1' }
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, anything, anything, query)
       r = test_resource.new_with_client(double, @attrs)
       r.bills
@@ -365,7 +365,7 @@ describe GoCardless::Resource do
 
     it "adds provided params to existing query string params" do
       params = { 'merchant_id' => '1', :amount => '10.00' }
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, anything, anything, params)
       r = test_resource.new_with_client(double, @attrs)
       r.bills(:amount => '10.00')
@@ -373,7 +373,7 @@ describe GoCardless::Resource do
 
     it "adds provided params when there are no existing query string params" do
       params = { :source_id => 'xxx' }
-      GoCardless::Paginator.should_receive(:new).
+      expect(GoCardless::Paginator).to receive(:new).
                             with(anything, anything, anything, params)
       r = test_resource.new_with_client(double, {
         'sub_resource_uris' => {
@@ -385,7 +385,7 @@ describe GoCardless::Resource do
 
     it "return instances of the correct resource class" do
       r = test_resource.new_with_client(double, @attrs)
-      r.bills.should be_a GoCardless::Paginator
+      expect(r.bills).to be_a GoCardless::Paginator
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,10 @@ require 'gocardless'
 
 def stub_get(client, data)
   response = double
-  response.stub(:parsed).and_return(data)
+  allow(response).to receive(:parsed).and_return(data)
 
   token = client.instance_variable_get(:@access_token)
-  token.stub(:get).and_return response
+  allow(token).to receive(:get).and_return response
 end
 
 def unset_ivar(obj, var)
@@ -17,12 +17,12 @@ shared_examples_for "it has a query method for" do |status|
   describe "##{status}?" do
     context "when #{status}" do
       let(:object) { described_class.new(:status => status) }
-      specify { object.send("#{status}?").should be_truthy }
+      specify { expect(object.send("#{status}?")).to be_truthy }
     end
 
     context "when not #{status}" do
       let(:object) { described_class.new }
-      specify { object.send("#{status}?").should be_falsey }
+      specify { expect(object.send("#{status}?")).to be_falsey }
     end
   end
 end

--- a/spec/subscription_spec.rb
+++ b/spec/subscription_spec.rb
@@ -9,7 +9,7 @@ describe GoCardless::Subscription do
   let(:subscription) { GoCardless::Subscription.new(:id => '009988') }
 
   it "should be cancellable" do
-    client.should_receive(:api_put).with('/subscriptions/009988/cancel')
+    expect(client).to receive(:api_put).with('/subscriptions/009988/cancel')
     subscription.cancel!
   end
 

--- a/spec/user_spec.rb
+++ b/spec/user_spec.rb
@@ -7,25 +7,25 @@ describe GoCardless::User do
     context "with first and last name" do
       let(:first) { "First" }
       let(:last) { "Last" }
-      specify { user.name.should == "First Last" }
+      specify { expect(user.name).to eq("First Last") }
     end
 
     context "with first name only" do
       let(:first) { "First" }
       let(:last) { nil }
-      specify { user.name.should == "First" }
+      specify { expect(user.name).to eq("First") }
     end
 
     context "with last name only" do
       let(:first) { nil }
       let(:last) { "Last" }
-      specify { user.name.should == "Last" }
+      specify { expect(user.name).to eq("Last") }
     end
 
     context "with no first or last name" do
       let(:first) { nil }
       let(:last) { nil }
-      specify { user.name.should == "" }
+      specify { expect(user.name).to eq("") }
     end
   end
 end

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -7,33 +7,33 @@ describe GoCardless::Utils do
   describe "string helpers" do
     describe ".camelize" do
       it "converts underscored words to camel case" do
-        GoCardless::Utils.camelize("a_test_string").should == "ATestString"
+        expect(GoCardless::Utils.camelize("a_test_string")).to eq("ATestString")
       end
     end
 
     describe ".underscore" do
       it "converts camel case words to underscored form" do
-        GoCardless::Utils.underscore("ATestString").should == "a_test_string"
+        expect(GoCardless::Utils.underscore("ATestString")).to eq("a_test_string")
       end
     end
 
     describe ".singularize" do
       it "removes trailing 's' characters" do
-        GoCardless::Utils.singularize("desks").should == "desk"
+        expect(GoCardless::Utils.singularize("desks")).to eq("desk")
       end
 
       it "converts 'i' suffix to 'us'" do
-        GoCardless::Utils.singularize("cacti").should == "cactus"
+        expect(GoCardless::Utils.singularize("cacti")).to eq("cactus")
       end
     end
 
     describe '.secure_compare' do
       it 'is true for the same strings' do
-        GoCardless::Utils.secure_compare('hello', 'hello').should be_truthy
+        expect(GoCardless::Utils.secure_compare('hello', 'hello')).to be_truthy
       end
 
       it 'is false for different strings' do
-        GoCardless::Utils.secure_compare('hello', 'banjo').should be_falsey
+        expect(GoCardless::Utils.secure_compare('hello', 'banjo')).to be_falsey
       end
     end
   end
@@ -43,27 +43,27 @@ describe GoCardless::Utils do
       it "converts keys to symbols" do
         hash = {'string' => true, 123 => true, :symbol => true}
         keys = GoCardless::Utils.symbolize_keys(hash).keys
-        keys.length.should == 3
-        keys.should include :string
-        keys.should include :'123'
-        keys.should include :symbol
+        expect(keys.length).to eq(3)
+        expect(keys).to include :string
+        expect(keys).to include :'123'
+        expect(keys).to include :symbol
       end
 
       it "preserves the original hash" do
         hash = {'string' => true}
         GoCardless::Utils.symbolize_keys(hash)
-        hash.keys.should == ['string']
+        expect(hash.keys).to eq(['string'])
       end
 
       it "doesn't overwrite existing symbol keys" do
         hash = {'x' => 1, :x => 2}
-        GoCardless::Utils.symbolize_keys(hash).should == hash
+        expect(GoCardless::Utils.symbolize_keys(hash)).to eq(hash)
       end
 
       it "works with sinatra params' default proc" do
         hash = Hash.new {|hash,key| hash[key.to_s] if Symbol === key }
         hash['x'] = 1
-        GoCardless::Utils.symbolize_keys(hash).should == {:x => 1}
+        expect(GoCardless::Utils.symbolize_keys(hash)).to eq({:x => 1})
       end
     end
 
@@ -71,7 +71,7 @@ describe GoCardless::Utils do
       it "modifies the original hash" do
         hash = {'string' => true}
         GoCardless::Utils.symbolize_keys!(hash)
-        hash.keys.should == [:string]
+        expect(hash.keys).to eq([:string])
       end
     end
   end
@@ -81,37 +81,37 @@ describe GoCardless::Utils do
       subject { GoCardless::Utils.method(:percent_encode) }
 
       it "works with empty strings" do
-        subject[""].should == ""
+        expect(subject[""]).to eq("")
       end
 
       it "doesn't encode lowercase alpha characters" do
-        subject["abcxyz"].should == "abcxyz"
+        expect(subject["abcxyz"]).to eq("abcxyz")
       end
 
       it "doesn't encode uppercase alpha characters" do
-        subject["ABCXYZ"].should == "ABCXYZ"
+        expect(subject["ABCXYZ"]).to eq("ABCXYZ")
       end
 
       it "doesn't encode digits" do
-        subject["1234567890"].should == "1234567890"
+        expect(subject["1234567890"]).to eq("1234567890")
       end
 
       it "doesn't encode unreserved non-alphanumeric characters" do
-        subject["-._~"].should == "-._~"
+        expect(subject["-._~"]).to eq("-._~")
       end
 
       it "encodes non-ascii alpha characters" do
-        subject["å"].should == "%C3%A5"
+        expect(subject["å"]).to eq("%C3%A5")
       end
 
       it "encodes reserved ascii characters" do
-        subject[" !\"\#$%&'()"].should == "%20%21%22%23%24%25%26%27%28%29"
-        subject["*+,/{|}:;"].should == "%2A%2B%2C%2F%7B%7C%7D%3A%3B"
-        subject["<=>?@[\\]^`"].should == "%3C%3D%3E%3F%40%5B%5C%5D%5E%60"
+        expect(subject[" !\"\#$%&'()"]).to eq("%20%21%22%23%24%25%26%27%28%29")
+        expect(subject["*+,/{|}:;"]).to eq("%2A%2B%2C%2F%7B%7C%7D%3A%3B")
+        expect(subject["<=>?@[\\]^`"]).to eq("%3C%3D%3E%3F%40%5B%5C%5D%5E%60")
       end
 
       it "encodes other non-ascii characters" do
-        subject["支払い"].should == "%E6%94%AF%E6%89%95%E3%81%84"
+        expect(subject["支払い"]).to eq("%E6%94%AF%E6%89%95%E3%81%84")
       end
     end
 
@@ -119,66 +119,66 @@ describe GoCardless::Utils do
       subject { GoCardless::Utils.method(:flatten_params) }
 
       it "and_return an empty array when provided with an empty hash" do
-        subject[{}].should == []
+        expect(subject[{}]).to eq([])
       end
 
       it "converts hashes to key-value arrays" do
-        subject['a' => 'b'].should == [['a', 'b']]
+        expect(subject['a' => 'b']).to eq([['a', 'b']])
       end
 
       it "works with integer keys and values" do
-        subject[123 => 456].should == [['123', '456']]
+        expect(subject[123 => 456]).to eq([['123', '456']])
       end
 
       it "converts DateTime objects to ISO8601-fomatted strings" do
         date = '2001-02-03T12:23:45Z'
-        subject[:date => Time.parse(date)][0][1].should == date
+        expect(subject[:date => Time.parse(date)][0][1]).to eq(date)
       end
 
       it "works with symbol keys and values" do
-        subject[:a => :b].should == [['a', 'b']]
+        expect(subject[:a => :b]).to eq([['a', 'b']])
       end
 
       it "uses empty-bracket syntax for arrays" do
-        subject['a' => ['b']].should == [['a[]', 'b']]
+        expect(subject['a' => ['b']]).to eq([['a[]', 'b']])
       end
 
       it "excludes values with empty arrays" do
-        subject['a' => []].should == []
+        expect(subject['a' => []]).to eq([])
       end
 
       it "includes all array values separately" do
         result = subject['a' => ['b', 'c']]
-        result.should include ['a[]', 'b']
-        result.should include ['a[]', 'c']
-        result.length.should == 2
+        expect(result).to include ['a[]', 'b']
+        expect(result).to include ['a[]', 'c']
+        expect(result.length).to eq(2)
       end
 
       it "flattens nested arrays" do
-        subject['a' => [['b']]].should == [['a[][]', 'b']]
+        expect(subject['a' => [['b']]]).to eq([['a[][]', 'b']])
       end
 
       it "uses the bracket-syntax for hashes" do
-        subject['a' => {'b' => 'c'}].should == [['a[b]', 'c']]
+        expect(subject['a' => {'b' => 'c'}]).to eq([['a[b]', 'c']])
       end
 
       it "includes all hash k/v pairs separately" do
         result = subject['a' => {'b' => 'c', 'd' => 'e'}]
-        result.should include ['a[b]', 'c']
-        result.should include ['a[d]', 'e']
-        result.length.should == 2
+        expect(result).to include ['a[b]', 'c']
+        expect(result).to include ['a[d]', 'e']
+        expect(result.length).to eq(2)
       end
 
       it "flattens nested hashes" do
-        subject['a' => {'b' => {'c' => 'd'}}].should == [['a[b][c]', 'd']]
+        expect(subject['a' => {'b' => {'c' => 'd'}}]).to eq([['a[b][c]', 'd']])
       end
 
       it "works with arrays inside hashes" do
-        subject['a' => {'b' => ['c']}].should == [['a[b][]', 'c']]
+        expect(subject['a' => {'b' => ['c']}]).to eq([['a[b][]', 'c']])
       end
 
       it "works with hashes inside arrays" do
-        subject['a' => [{'b' => 'c'}]].should == [['a[][b]', 'c']]
+        expect(subject['a' => [{'b' => 'c'}]]).to eq([['a[][b]', 'c']])
       end
     end
 
@@ -186,19 +186,19 @@ describe GoCardless::Utils do
       subject { GoCardless::Utils.method(:normalize_params) }
 
       it "percent encodes keys and values" do
-        subject['!' => '+'].split('=').should == ['%21', '%2B']
+        expect(subject['!' => '+'].split('=')).to eq(['%21', '%2B'])
       end
 
       it "joins items by '=' signs" do
-        subject['a' => 'b'].should == 'a=b'
+        expect(subject['a' => 'b']).to eq('a=b')
       end
 
       it "joins pairs by '&' signs" do
-        subject['a' => 'b', 'c' => 'd'].should == 'a=b&c=d'
+        expect(subject['a' => 'b', 'c' => 'd']).to eq('a=b&c=d')
       end
 
       it "sorts pairs by name then value" do
-        subject['a0' => 'b', 'a' => 'c'].should == 'a=c&a0=b'
+        expect(subject['a0' => 'b', 'a' => 'c']).to eq('a=c&a0=b')
       end
     end
 
@@ -207,7 +207,7 @@ describe GoCardless::Utils do
         key = 'testsecret'
         params = {:test => true}
         sig = '6e4613b729ce15c288f70e72463739feeb05fc0b89b55d248d7f259b5367148b'
-        GoCardless::Utils.sign_params(params, key).should == sig
+        expect(GoCardless::Utils.sign_params(params, key)).to eq(sig)
       end
     end
   end
@@ -216,39 +216,39 @@ describe GoCardless::Utils do
     describe ".iso_format_time" do
       it "should work with a Time object" do
         d = GoCardless::Utils.iso_format_time(Time.parse("1st January 2012"))
-        d.should == "2012-01-01T00:00:00Z"
+        expect(d).to eq("2012-01-01T00:00:00Z")
       end
 
       it "should work with a DateTime object" do
         d = GoCardless::Utils.iso_format_time(DateTime.parse("1st January 2012"))
-        d.should == "2012-01-01T00:00:00Z"
+        expect(d).to eq("2012-01-01T00:00:00Z")
       end
 
       it "should work with a Date object" do
         d = GoCardless::Utils.iso_format_time(Date.parse("1st January 2012"))
-        d.should == "2012-01-01T00:00:00Z"
+        expect(d).to eq("2012-01-01T00:00:00Z")
       end
 
       it "should leave a string untouched" do
         date = "1st January 2012"
-        GoCardless::Utils.iso_format_time(date).should == date
+        expect(GoCardless::Utils.iso_format_time(date)).to eq(date)
       end
     end
 
     describe ".stringify_times" do
       it "stringifies time objects" do
         d = GoCardless::Utils.stringify_times(Time.parse("1st Jan 2012"))
-        d.should == "2012-01-01T00:00:00Z"
+        expect(d).to eq("2012-01-01T00:00:00Z")
       end
 
       it "stringifies time values in hashes" do
         d = GoCardless::Utils.stringify_times(:t => Time.parse("1st Jan 2012"))
-        d.should == { :t => "2012-01-01T00:00:00Z" }
+        expect(d).to eq({ :t => "2012-01-01T00:00:00Z" })
       end
 
       it "stringifies time values in arrays" do
         d = GoCardless::Utils.stringify_times([Time.parse("1st Jan 2012")])
-        d.should == ["2012-01-01T00:00:00Z"]
+        expect(d).to eq(["2012-01-01T00:00:00Z"])
       end
     end
   end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.7 with the following command:
    transpec -f

```
* 171 conversions
    from: obj.should
      to: expect(obj).to

* 109 conversions
    from: == expected
      to: eq(expected)

* 43 conversions
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

* 15 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 14 conversions
    from: obj.stub(:message)
      to: allow(obj).to receive(:message)

* 4 conversions
    from: lambda { }.should
      to: expect { }.to

* 2 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 2 conversions
    from: obj.should_not_receive(:message)
      to: expect(obj).not_to receive(:message)

* 2 conversions
    from: obj.stub(:message => value)
      to: allow(obj).to receive_messages(:message => value)
```

For more details: https://github.com/yujinakayama/transpec#supported-conversions
