### PR TITLE
Stop testing against Ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,8 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.9.2
-  - 1.8.7
-  - jruby-18mode
   - jruby-19mode
   - rbx-2
-  - ree
 notifications:
   email:
     recipients:


### PR DESCRIPTION
- The only people this might affect are people running 1.8.7
- If people are running 1.8.7 they haven't updated this gem in 6 months (when we started tracking versions)
- If they haven't updated this gem in 6 months, it's unlikely we need to worry about them being desperate to upgrade now and providing backwards compatible support

@hmarr For now this just stops testing against old versions, once merged I'll rebase https://github.com/gocardless/gocardless-ruby/pull/70 and get green specs.

Sound good?
