### PR TITLE
Update Gem Dependencies

### DIFF
--- a/gocardless.gemspec
+++ b/gocardless.gemspec
@@ -1,13 +1,13 @@
 require File.expand_path('../lib/gocardless/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'oauth2', '~> 0.7'
-  gem.add_runtime_dependency 'multi_json', '~> 1.0'
+  gem.add_runtime_dependency 'oauth2', '~> 1.0'
+  gem.add_runtime_dependency 'multi_json', '~> 1.10'
 
   gem.add_development_dependency 'rspec', '~> 2.13'
-  gem.add_development_dependency 'yard', '~> 0.7'
-  gem.add_development_dependency 'activesupport', '~> 3.1'
-  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'yard', '~> 0.8'
+  gem.add_development_dependency 'activesupport', '~> 3.2'
+  gem.add_development_dependency 'rake', '~> 10.3'
 
   gem.authors = ['Harry Marr', 'Tom Blomfield']
   gem.description = %q{A Ruby wrapper for the GoCardless API}


### PR DESCRIPTION
These are the latest versions of the gem dependencies.

I don't envision any issues - oauth 1.0 (https://github.com/gocardless/gocardless-ruby/issues/67) seems like a sensible improvement, `multi_json` hasn't had a major version bump and the others are development dependencies. Would be nice to get these shiny before we do a major version bump.
